### PR TITLE
Bei einer unhandled exception wird auf die page /Error verwiesen. Die…

### DIFF
--- a/Remote/Startup.cs
+++ b/Remote/Startup.cs
@@ -87,10 +87,11 @@ namespace Dvelop.Remote
                             .RequireAuthenticatedUser()
                             .Build();
                         options.Filters.Add(new AuthorizeFilter(policy));
-
-    
-                    }
-                )
+                    })
+                .AddRazorPagesOptions(options => 
+                    {
+                        options.Conventions.AllowAnonymousToPage("/Error");
+                    })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1); // Should be set to 2.1 compatibility
             services.AddDirectoryBrowser();
             return _factory.CreateServiceProvider(services);


### PR DESCRIPTION
…se war bislang nicht anonym erreichbar weshalb ein redirect (302) zur IDP zurückgegeben wurde, anstatt die ErrorPage auszuliefern.

Das ist während der Entwicklung nicht aufgefallen da im Fehlerfall eine detaillierte Fehlerseite von MVC generiert wird, die in Produktion nicht eingesetzt werden sollte, da sie interne Informationen preisgeben könnte (sicherheitsrisiko).

Fazit: Die Error-Page sollte anonym erreichbar sein, damit ist das Problem gelöst.