### PR TITLE
Fix compiler warning NETSDK1071

### DIFF
--- a/AwsLambda/Entrypoint/EntryPoint.csproj
+++ b/AwsLambda/Entrypoint/EntryPoint.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeFramework>2.1.5</RuntimeFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ApplicationIcon />
@@ -12,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="2.1.0" />
-	<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+	<PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\Domain.csproj" />

--- a/AwsLambda/Entrypoint/EntryPoint.csproj
+++ b/AwsLambda/Entrypoint/EntryPoint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeFramework>2.1.5</RuntimeFramework>
+    <RuntimeFrameworkVersion>2.1.5</RuntimeFrameworkVersion>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ApplicationIcon />

--- a/Remote/Remote.csproj
+++ b/Remote/Remote.csproj
@@ -40,7 +40,7 @@
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
 		<RootNamespace>Dvelop.Remote</RootNamespace>
-		<RuntimeFramework>2.1.5</RuntimeFramework>
+		<RuntimeFrameworkVersion>2.1.5</RuntimeFrameworkVersion>
 		<TypeScriptToolsVersion>3.1</TypeScriptToolsVersion>
 	</PropertyGroup>
   

--- a/Remote/Remote.csproj
+++ b/Remote/Remote.csproj
@@ -3,7 +3,7 @@
 	 <ItemGroup>
 			<PackageReference Include="dvelop.IdentityProviderClient" Version="2.1.2" />
 			<PackageReference Include="dvelop.TenantMiddleware" Version="1.0.2" />
-			<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+			<PackageReference Include="Microsoft.AspNetCore.App" />
 	 </ItemGroup>
 	
 	 <ItemGroup>
@@ -40,6 +40,7 @@
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
 		<RootNamespace>Dvelop.Remote</RootNamespace>
+		<RuntimeFramework>2.1.5</RuntimeFramework>
 		<TypeScriptToolsVersion>3.1</TypeScriptToolsVersion>
 	</PropertyGroup>
   

--- a/SelfHosted/HostApplication/HostApplication.csproj
+++ b/SelfHosted/HostApplication/HostApplication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
+		<PackageReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -14,6 +14,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>netcoreapp2.1</TargetFramework>
+		<RuntimeFramework>2.1.5</RuntimeFramework>
 		<StartupObject>Dvelop.Selfhosted.HostApplication.Program</StartupObject>
 		<RootNamespace>Dvelop.Selfhosted.HostApplication</RootNamespace>
 	</PropertyGroup>

--- a/SelfHosted/HostApplication/HostApplication.csproj
+++ b/SelfHosted/HostApplication/HostApplication.csproj
@@ -14,7 +14,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>netcoreapp2.1</TargetFramework>
-		<RuntimeFramework>2.1.5</RuntimeFramework>
+		<RuntimeFrameworkVersion>2.1.5</RuntimeFrameworkVersion>
 		<StartupObject>Dvelop.Selfhosted.HostApplication.Program</StartupObject>
 		<RootNamespace>Dvelop.Selfhosted.HostApplication</RootNamespace>
 	</PropertyGroup>


### PR DESCRIPTION
According to https://aka.ms/sdkimplicitrefs, ASP.NET Core should use implicit package versions and only restrict the version using `RuntimeFramework`.