### PR TITLE
Cache NuGet packages for faster restore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,4 @@
 .git/
 .vs/
 .vscode/
-Adapter/
-AwsLambda/
-Domain/
-Domain.UnitTests/
 dist/
-Remote/
-SelfHosted/

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -64,7 +64,23 @@ RUN curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundl
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && rm -rf ./awscli-bundle
 
-COPY umask.sh /
+# Copy project structure to populate the nuget cache
+WORKDIR /tmp/cache
+COPY ./AcmeTemplate.sln ./NuGet.config ./
+COPY ./AwsLambda/Entrypoint/EntryPoint.csproj ./AwsLambda/Entrypoint/EntryPoint.csproj
+COPY ./Domain/Domain.csproj ./Domain/Domain.csproj
+COPY ./Domain.UnitTests/Domain.UnitTests.csproj ./Domain.UnitTests/Domain.UnitTests.csproj
+COPY ./Plugins/DynamoDbFake/DynamoDbFake.csproj ./Plugins/DynamoDbFake/DynamoDbFake.csproj
+COPY ./Plugins/InMemoryDb/InMemoryDb.csproj ./Plugins/InMemoryDb/InMemoryDb.csproj
+COPY ./Plugins/WebApi/WebApi.csproj ./Plugins/WebApi/WebApi.csproj
+COPY ./Remote/Remote.csproj ./Remote/Remote.csproj
+COPY ./SelfHosted/HostApplication/HostApplication.csproj ./SelfHosted/HostApplication/HostApplication.csproj
+RUN set -x \
+    && dotnet restore \
+    && rm -rf /tmp/cache
+
+WORKDIR /build
+COPY buildcontainer/umask.sh /
 RUN chmod +x /umask.sh
 	
 WORKDIR /build

--- a/docker-build.bat
+++ b/docker-build.bat
@@ -11,7 +11,7 @@ for /f "usebackq delims=" %%a in ("environment") do (
 )
 
 echo Building new docker image ...
-docker build -t %BUILDCONTAINER% ./buildcontainer > ./buildcontainer/build.log && (
+docker build -t %BUILDCONTAINER% -f ./buildcontainer/Dockerfile . > ./buildcontainer/build.log && (
     echo done
 ) || (
     echo error building image

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,7 +9,7 @@ for var in $(cat environment); do
 done
 
 echo "Building new docker image ..."
-docker build -t ${BUILDCONTAINER} ./buildcontainer > ./buildcontainer/build.log
+docker build -t ${BUILDCONTAINER} -f ./buildcontainer/Dockerfile . > ./buildcontainer/build.log
 if [[ $? -eq 0 ]]; then
     echo "done"
 else


### PR DESCRIPTION
I'm not quite sure if the updated .dockerignore is worth it, but manually copying the sln/csproj files to the Docker container seems to be one of the best/fastest ways to [cache NuGet packages](https://andrewlock.net/optimising-asp-net-core-apps-in-docker-avoiding-manually-copying-csproj-files/) for a Docker build. The main reason is that it drastically reduces the amount of files that need to be checked. Unfortunately, it also adds several intermediary images and needs to be modified for every added/removed csproj.

A better solution might be to [tar/zip](https://andrewlock.net/optimising-asp-net-core-apps-in-docker-avoiding-manually-copying-csproj-files-part-2/#option-2-creating-a-tar-ball-of-the-project-files) the project files, but it's a bit more complicated to implement cross-platform in build-docker.bat.

If merged, this fixes #21 