### PR TITLE
Split docker build from VS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@
 .vs/
 .vscode/
 dist/
+terraform/
+**/bin/
+**/obj/
+**/out/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,4 @@
 .git/
 .vs/
 .vscode/
-Adapter/
-AwsLambda/
-Domain/
-Domain.UnitTests/
 dist/
-Remote/
-SelfHosted/

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -80,6 +80,8 @@ RUN set -x \
     && rm -rf /tmp/cache
 
 WORKDIR /build
+COPY . /build
+
 COPY buildcontainer/umask.sh /
 RUN chmod +x /umask.sh
 	

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -64,7 +64,23 @@ RUN curl -sSL https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundl
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && rm -rf ./awscli-bundle
 
-COPY umask.sh /
+# Copy project structure to populate the nuget cache
+WORKDIR /tmp/cache
+COPY ./AcmeTemplate.sln ./NuGet.config ./
+COPY ./AwsLambda/Entrypoint/EntryPoint.csproj ./AwsLambda/Entrypoint/EntryPoint.csproj
+COPY ./Domain/Domain.csproj ./Domain/Domain.csproj
+COPY ./Domain.UnitTests/Domain.UnitTests.csproj ./Domain.UnitTests/Domain.UnitTests.csproj
+COPY ./Plugins/DynamoDbFake/DynamoDbFake.csproj ./Plugins/DynamoDbFake/DynamoDbFake.csproj
+COPY ./Plugins/InMemoryDb/InMemoryDb.csproj ./Plugins/InMemoryDb/InMemoryDb.csproj
+COPY ./Plugins/WebApi/WebApi.csproj ./Plugins/WebApi/WebApi.csproj
+COPY ./Remote/Remote.csproj ./Remote/Remote.csproj
+COPY ./SelfHosted/HostApplication/HostApplication.csproj ./SelfHosted/HostApplication/HostApplication.csproj
+RUN set -x \
+    && dotnet restore \
+    && rm -rf /tmp/cache
+
+WORKDIR /build
+COPY buildcontainer/umask.sh /
 RUN chmod +x /umask.sh
 	
 WORKDIR /build

--- a/docker-build.bat
+++ b/docker-build.bat
@@ -11,7 +11,7 @@ for /f "usebackq delims=" %%a in ("environment") do (
 )
 
 echo Building new docker image ...
-docker build -t %BUILDCONTAINER% ./buildcontainer > ./buildcontainer/build.log && (
+docker build -t %BUILDCONTAINER% -f ./buildcontainer/Dockerfile . > ./buildcontainer/build.log && (
     echo done
 ) || (
     echo error building image

--- a/docker-build.bat
+++ b/docker-build.bat
@@ -21,7 +21,7 @@ docker build -t %BUILDCONTAINER% -f ./buildcontainer/Dockerfile . > ./buildconta
 setlocal disabledelayedexpansion
 
 if "%1"=="it" (
-    docker run -it --rm %denv% -v %cd%:/build --entrypoint /bin/bash %BUILDCONTAINER%
+    docker run -it --rm %denv% -v %cd%/terraform:/build/terraform --entrypoint /bin/bash %BUILDCONTAINER%
 ) else (
-    docker run --rm %denv% -v %cd%:/build %BUILDCONTAINER% %*
+    docker run --rm %denv% -v %cd%/terraform:/build/terraform %BUILDCONTAINER% %*
 )

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,7 +9,7 @@ for var in $(cat environment); do
 done
 
 echo "Building new docker image ..."
-docker build -t ${BUILDCONTAINER} ./buildcontainer > ./buildcontainer/build.log
+docker build -t ${BUILDCONTAINER} -f ./buildcontainer/Dockerfile . > ./buildcontainer/build.log
 if [[ $? -eq 0 ]]; then
     echo "done"
 else

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -18,7 +18,7 @@ else
 fi
 
 if [[ "$1" = "it" ]]; then
-    docker run -it --rm ${DENV} --mount type=bind,src="$(pwd)",dst=/build --entrypoint /bin/bash ${BUILDCONTAINER}
+    docker run -it --rm ${DENV} --mount type=bind,src="$(pwd)/terraform",dst=/build/terraform --entrypoint /bin/bash ${BUILDCONTAINER}
 else
-    docker run --rm ${DENV} --mount type=bind,src="$(pwd)",dst=/build ${BUILDCONTAINER} "$@"
+    docker run --rm ${DENV} --mount type=bind,src="$(pwd)/terraform",dst=/build/terraform ${BUILDCONTAINER} "$@"
 fi


### PR DESCRIPTION
Unless there is another reason than having `terraform\.terraform` as a place to store some persistent data, which requires the source directory to be mounted as a volume, this is an easy way to allow running `docker build` without disturbing running instanced of an IDE.

Fixes #2 