### PR TITLE
Added provider before terraform init in container build process

### DIFF
--- a/AcmeTemplate.sln
+++ b/AcmeTemplate.sln
@@ -32,7 +32,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "terraform", "terraform", "{
 		terraform\backend.tf = terraform\backend.tf
 		terraform\main.tf = terraform\main.tf
 		terraform\outputs.tf = terraform\outputs.tf
-		terraform\provider.tf = terraform\provider.tf
 		terraform\variables.tf = terraform\variables.tf
 	EndProjectSection
 EndProject

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ tf-bucket:
 tf-init: tf-bucket
 	echo "Initializing terraform"
 	cd /build/terraform && \
-	terraform init -input=false -plugin-dir=/usr/local/lib/custom-terraform-plugins -backend-config=backendconfig/$(SYSTEM_PREFIX)backend.tfbackend
+	terraform init -input=false -backend-config=backendconfig/$(SYSTEM_PREFIX)backend.tfbackend
 
 plan: tf-init build-lambda asset_hash
 	echo "Planning terraform changes"

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -9,6 +9,20 @@ RUN rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
 
+ENV TERRAFORM_AWS_PLUGIN_VERSION 3.52.0 
+ENV TERRAFORM_TEMPLATE_PLUGIN_VERSION 2.2.0
+ENV TERRAFORM_TERRAFORM_PLUGIN_VERSION 2.2.0
+
+#create terraforms default local provider structure
+RUN mkdir -p ~/.terraform.d ~/.terraform.d/plugins -p ~/.terraform.d/plugins/registry.terraform.io/ ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \
+    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws && \ 
+    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/template && \
+    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive && \
+    cd ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \
+    mkdir -p aws/${TERRAFORM_AWS_PLUGIN_VERSION} aws/${TERRAFORM_AWS_PLUGIN_VERSION}/linux_amd64 && \
+    mkdir -p template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION} template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/linux_amd64 && \
+    mkdir -p archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION} archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/linux_amd64
+    
 # packer
 ENV PACKER_VERSION 1.2.5
 ENV PACKER_CHECKSUM bc58aa3f3db380b76776e35f69662b49f3cf15cf80420fc81a15ce971430824c
@@ -17,49 +31,30 @@ RUN curl -fsSL https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${
     unzip packer.zip -d /usr/local/bin && chmod +x /usr/local/bin/packer ; rm packer.zip
 
 # terraform
-ENV TERRAFORM_VERSION 0.12.26
-ENV TERRAFORM_CHECKSUM 607bc802b1c6c2a5e62cc48640f38aaa64bef1501b46f0ae4829feb51594b257
+ENV TERRAFORM_VERSION 0.13.7
+ENV TERRAFORM_CHECKSUM 4a52886e019b4fdad2439da5ff43388bbcc6cce9784fde32c53dcd0e28ca9957
 RUN curl -fsSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o terraform.zip  && \
     echo "${TERRAFORM_CHECKSUM} terraform.zip" | sha256sum -c - && \
     unzip terraform.zip -d /usr/local/bin && chmod +x /usr/local/bin/terraform ; rm terraform.zip
 
-# terraform terraform provider plugin (for remote state)
-ENV TERRAFORM_TERRAFORM_PLUGIN_VERSION 1.0.2
-ENV TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM c4c1e826c85ef45fb18ca75e06284d13b0f72bce61a652e74eb016cf7779eafd
-RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-terraform/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/terraform-provider-terraform_${TERRAFORM_TERRAFORM_PLUGIN_VERSION}_linux_amd64.zip -o terraform_terraform_plugin.zip  && \
-    echo "${TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM} terraform_terraform_plugin.zip" | sha256sum -c - && \
-    unzip terraform_terraform_plugin.zip -d /usr/local/lib/custom-terraform-plugins ; rm terraform_terraform_plugin.zip
-
-
-# terraform mongodbatlas provider plugin (for mongodbatlas)
-ENV TERRAFORM_MONGODBATLAS_PLUGIN_VERSION 0.5.1
-ENV TERRAFORM_MONGODBATLAS_PLUGIN_CHECKSUM 70166a9f2022f1ff96a1841648a8282a4cfcc38a6dc592df7b9a78a600d3d87c
-RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-mongodbatlas/${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}/terraform-provider-mongodbatlas_${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}_linux_amd64.zip -o terraform_mongodbatlas_plugin.zip  && \
-    echo "${TERRAFORM_MONGODBATLAS_PLUGIN_CHECKSUM} terraform_mongodbatlas_plugin.zip" | sha256sum -c - && \
-    unzip terraform_mongodbatlas_plugin.zip -d /usr/local/lib/custom-terraform-plugins ; rm terraform_mongodbatlas_plugin.zip
-
 # terraform template provider plugin
-ENV TERRAFORM_TEMPLATE_PLUGIN_VERSION 2.1.2
-ENV TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM 149e4bf47ac21b67f6567767afcd29caaf0b0ca43714748093a00a2a98cd17a8
+ENV TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM 8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae
 RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/terraform-provider-template_${TERRAFORM_TEMPLATE_PLUGIN_VERSION}_linux_amd64.zip -o terraform_template_plugin.zip  && \
     echo "${TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM} terraform_template_plugin.zip" | sha256sum -c - && \
-    unzip terraform_template_plugin.zip -d /usr/local/lib/custom-terraform-plugins ; rm terraform_template_plugin.zip
+    unzip terraform_template_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_template_plugin.zip
 
 # terraform aws provider plugin
-ENV TERRAFORM_AWS_PLUGIN_VERSION 2.64.0 
-ENV TERRAFORM_AWS_PLUGIN_CHECKSUM faf2b833298d5a958a94963f1b0a5d3501b80725148a7fb81e5535f2ecba9edf
+ENV TERRAFORM_AWS_PLUGIN_CHECKSUM 2e0432fabeb5e44d756a5566168768f1b6dea3cc0e5650fac966820e90d18367
 RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_AWS_PLUGIN_VERSION}/terraform-provider-aws_${TERRAFORM_AWS_PLUGIN_VERSION}_linux_amd64.zip -o terraform_aws_plugin.zip  && \
     echo "${TERRAFORM_AWS_PLUGIN_CHECKSUM} terraform_aws_plugin.zip" | sha256sum -c - && \
-    unzip terraform_aws_plugin.zip -d /usr/local/lib/custom-terraform-plugins ; rm terraform_aws_plugin.zip
+    unzip terraform_aws_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/${TERRAFORM_AWS_PLUGIN_VERSION}/linux_amd64/  ; rm terraform_aws_plugin.zip
 
 # terraform terraform provider archive (for lambda)
-ENV TERRAFORM_TERRAFORM_PLUGIN_VERSION 1.3.0
-ENV TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM e0d1213625d40d124bd9570f0d92907416f8d61bc8c389c776e72c0a97020cce
+ENV TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65
 RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/terraform-provider-archive_${TERRAFORM_TERRAFORM_PLUGIN_VERSION}_linux_amd64.zip -o terraform_terraform_plugin.zip  && \
     echo "${TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM} terraform_terraform_plugin.zip" | sha256sum -c - && \
-    unzip terraform_terraform_plugin.zip -d /usr/local/lib/custom-terraform-plugins ; rm terraform_terraform_plugin.zip
+    unzip terraform_terraform_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_terraform_plugin.zip
 
-# aws cli
 RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip && \
     unzip awscliv2.zip && \
     aws/install -i /usr/local/aws -b /usr/local/bin && \

--- a/terraform/modules/serverless_lambda_app/main.tf
+++ b/terraform/modules/serverless_lambda_app/main.tf
@@ -1,7 +1,6 @@
 #cf. https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
 resource "aws_s3_bucket" "assets" {
   bucket = var.assets_bucket_name
-  region = var.aws_region
 
   # required if webfonts are delivered cf. https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html and https://zinoui.com/blog/cross-domain-fonts
   cors_rule {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,5 +1,11 @@
-provider "aws" {
-  version = "~> 2.0"
+﻿provider "aws" {
   region  = var.aws_region
 }
 
+provider "archive" {
+  # Configuration options
+}
+
+provider "template" {
+  # Configuration options
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,4 +1,17 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.52.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "2.2.0"
+    }
+  }
 }


### PR DESCRIPTION
I´ve added the default provider folder structure of terraform 0.13. Normally, this structure is build with the mirror command.
https://www.terraform.io/upgrade-guides/0-13.html
https://www.terraform.io/docs/cli/commands/providers/mirror.html
https://www.terraform.io/docs/cli/config/config-file.html#explicit-installation-method-configuration
Since the providers should be downloaded in the build process, i manually added the needed structure.