### PR TITLE
Update the lambda configuration and lambda to run with dotnet 6.0

### DIFF
--- a/AwsLambda/Entrypoint/EntryPoint.csproj
+++ b/AwsLambda/Entrypoint/EntryPoint.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <ApplicationIcon />
@@ -10,9 +10,9 @@
     <AssemblyName>EntryPoint</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="6.0.2" />
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.3.0" />
-    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.1.0" />
+	<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.1.0" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.7.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
     <PackageReference Include="Dvelop.Sdk.Logging.OtelJsonConsole" Version="0.0.6.118" />
   </ItemGroup>
   <ItemGroup>

--- a/AwsLambda/Entrypoint/EntryPoint.csproj
+++ b/AwsLambda/Entrypoint/EntryPoint.csproj
@@ -8,6 +8,7 @@
     <StartupObject />
     <RootNamespace>Dvelop.Lambda.EntryPoint</RootNamespace>
     <AssemblyName>EntryPoint</AssemblyName>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
 	<PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.1.0" />

--- a/AwsLambda/Entrypoint/HttpApiJsonSerializerContext.cs
+++ b/AwsLambda/Entrypoint/HttpApiJsonSerializerContext.cs
@@ -1,0 +1,11 @@
+﻿using System.Text.Json.Serialization;
+using Amazon.Lambda.APIGatewayEvents;
+
+namespace Dvelop.Lambda.EntryPoint
+{
+    [JsonSerializable(typeof(APIGatewayProxyRequest))]
+    [JsonSerializable(typeof(APIGatewayProxyResponse))]
+    public partial class HttpApiJsonSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/AwsLambda/Entrypoint/LambdaEntryPoint.cs
+++ b/AwsLambda/Entrypoint/LambdaEntryPoint.cs
@@ -1,16 +1,15 @@
-using System;
 using Amazon.Lambda.Core;
+using Amazon.Lambda.Serialization.SystemTextJson;
 using Dvelop.Lambda.EntryPoint.DependencyInjection;
 using Dvelop.Remote;
 using Dvelop.Sdk.Logging.OtelJsonConsole.Extension;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
-
-[assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+[assembly: LambdaSerializer(typeof(SourceGeneratorLambdaJsonSerializer<Dvelop.Lambda.EntryPoint.HttpApiJsonSerializerContext>))]
+//[assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 namespace Dvelop.Lambda.EntryPoint
 {
     /// <summary>
@@ -31,7 +30,7 @@ namespace Dvelop.Lambda.EntryPoint
         // 
         // Note: When using the AWS::Serverless::Function resource with an event type of "HttpApi" then payload version 2.0
         // will be the default and you must make Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction the base class.
-        Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction
+        Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
     {
         /// <summary>
         /// 

--- a/AwsLambda/Entrypoint/LambdaEntryPoint.cs
+++ b/AwsLambda/Entrypoint/LambdaEntryPoint.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 [assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 namespace Dvelop.Lambda.EntryPoint
@@ -30,7 +31,7 @@ namespace Dvelop.Lambda.EntryPoint
         // 
         // Note: When using the AWS::Serverless::Function resource with an event type of "HttpApi" then payload version 2.0
         // will be the default and you must make Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction the base class.
-        Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction
+        Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction
     {
         /// <summary>
         /// 

--- a/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/Domain.UnitTests/Domain.UnitTests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Domain.UnitTests/Domain.UnitTests.csproj
+++ b/Domain.UnitTests/Domain.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Domain/Domain.csproj
+++ b/Domain/Domain.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Domain</AssemblyName>
     <RootNamespace>Dvelop.Domain</RootNamespace>
+    <Nullable>disable</Nullable>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,14 @@ build: clean build-app build-lambda
 build-app: generate test
 	echo "Building app for Windows..."
 	dotnet publish --self-contained -r win-x64 -c Release ./SelfHosted/HostApplication/HostApplication.csproj
-	cd /buildinternal/SelfHosted/HostApplication/bin/Release/netcoreapp3.1/win-x64/publish/ && 	\
+	cd /buildinternal/SelfHosted/HostApplication/bin/Release/net6.0/win-x64/publish/ && 	\
 		echo "Creating windows_<rev>.zip from: " && \
 		zip -x wwwroot/dvelop-dux/images\* -r /build/dist/windows_$(BUILD_VERSION).zip .
 
 build-lambda: generate test
 	echo "Building lambda..."
 	dotnet publish -r linux-x64 --self-contained false -c Release ./AwsLambda/Entrypoint/EntryPoint.csproj
-	cd /buildinternal/AwsLambda/Entrypoint/bin/Release/netcoreapp3.1/linux-x64/publish/ && \
+	cd /buildinternal/AwsLambda/Entrypoint/bin/Release/net6.0/linux-x64/publish/ && \
 		echo "Creating lambda.zip from: " && \
 		zip -x wwwroot\* -r /build/dist/lambda.zip .
 
@@ -81,7 +81,7 @@ apply: plan
 deploy-assets: asset_hash apply
 	echo "Deploying static content to S3"
 	# best practice for immutable content: cache 1 year (vgl https://jakearchibald.com/2016/caching-best-practices/)
-	aws s3 sync /buildinternal/AwsLambda/Entrypoint/bin/Release/netcoreapp3.1/linux-x64/publish/wwwroot s3://assets.$(SYSTEM_PREFIX)$(APP_NAME)$(DOMAIN_SUFFIX)/$(ASSET_HASH) --exclude "*.html" --cache-control max-age=31536000
+	aws s3 sync /buildinternal/Remote/wwwroot s3://$(SYSTEM_PREFIX)$(APP_NAME)-assets/$(ASSET_HASH) --exclude "*.html" --cache-control max-age=31536000
 
 asset_hash:
 	echo "Creating hash for static content to create a cachable path within S3"

--- a/Plugins/DynamoDbFake/DynamoDbFake.csproj
+++ b/Plugins/DynamoDbFake/DynamoDbFake.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Dvelop.Plugins.DynamoDbFake</RootNamespace>
     <AssemblyName>Plugins.DynamoDbFake</AssemblyName>
+    <LangVersion>10</LangVersion>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Plugins/InMemoryDb/InMemoryDb.csproj
+++ b/Plugins/InMemoryDb/InMemoryDb.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>Plugins.InMemoryDb</AssemblyName>
         <RootNamespace>Dvelop.Plugins.InMemoryDb</RootNamespace>
+        <LangVersion>10</LangVersion>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Plugins/WebApi/WebApi.csproj
+++ b/Plugins/WebApi/WebApi.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Dvelop.Sdk.Logging.Abstractions" Version="0.0.6.118" />
       <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Plugins/WebApi/WebApi.csproj
+++ b/Plugins/WebApi/WebApi.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>netstandard2.1</TargetFramework>
         <AssemblyName>Plugins.WebApi</AssemblyName>
         <RootNamespace>Dvelop.Plugins.WebApi</RootNamespace>
+        <LangVersion>10</LangVersion>
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Remote.UnitTests/Remote.UnitTests.csproj
+++ b/Remote.UnitTests/Remote.UnitTests.csproj
@@ -4,6 +4,8 @@
         <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <Nullable>disable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Remote.UnitTests/Remote.UnitTests.csproj
+++ b/Remote.UnitTests/Remote.UnitTests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
-        <PackageReference Include="coverlet.collector" Version="3.0.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Remote/Remote.csproj
+++ b/Remote/Remote.csproj
@@ -3,7 +3,7 @@
 	 <ItemGroup>
 			<PackageReference Include="Dvelop.Sdk.Base.Dto" Version="0.0.6.118" />
 			<PackageReference Include="Dvelop.Sdk.CloudCenter.Dto" Version="0.0.6.118" />
-			<PackageReference Include="Dvelop.Sdk.Config.Dto" Version="0.0.6.117-prerelease" />
+			<PackageReference Include="Dvelop.Sdk.Config.Dto" Version="0.0.6.118" />
 			<PackageReference Include="Dvelop.Sdk.Home.Dto" Version="0.0.6.118" />
 			<PackageReference Include="Dvelop.Sdk.IdentityProvider.Middleware" Version="0.0.6.118" />
 			<PackageReference Include="Dvelop.Sdk.Logging.Abstractions" Version="0.0.6.118" />
@@ -43,7 +43,7 @@
 	 </ItemGroup>
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<ApplicationIcon />
 		<OutputType>Library</OutputType>
 		<RootNamespace>Dvelop.Remote</RootNamespace>

--- a/Remote/Remote.csproj
+++ b/Remote/Remote.csproj
@@ -48,6 +48,7 @@
 		<OutputType>Library</OutputType>
 		<RootNamespace>Dvelop.Remote</RootNamespace>
 		<TypeScriptToolsVersion>3.1</TypeScriptToolsVersion>
+		<Nullable>disable</Nullable>
 	</PropertyGroup>
   
 </Project>

--- a/Remote/Startup.cs
+++ b/Remote/Startup.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Dvelop.Sdk.TenantMiddleware;
 using Dvelop.Domain.Repositories;
 using Dvelop.Plugins.WebApi;
@@ -100,14 +101,16 @@ namespace Dvelop.Remote
                 {
                     options.Conventions.AllowAnonymousToPage("/Error");
                 })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+                //.SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddJsonOptions(options =>
                 {
-                    options.JsonSerializerOptions.IgnoreNullValues = true;
+                    //options.JsonSerializerOptions.IgnoreNullValues = true;
                     options.JsonSerializerOptions.WriteIndented = true;
                     options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
                     options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
+                    options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
                 });
+            
                 /* If you want to switch back to NewtonSoftJson, use to following settings
                 .AddNewtonsoftJson(options =>
                 {

--- a/SelfHosted/HostApplication/HostApplication.csproj
+++ b/SelfHosted/HostApplication/HostApplication.csproj
@@ -13,7 +13,7 @@
 	
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<StartupObject>Dvelop.Selfhosted.HostApplication.Program</StartupObject>
 		<RootNamespace>Dvelop.Selfhosted.HostApplication</RootNamespace>
 	</PropertyGroup>

--- a/SelfHosted/HostApplication/HostApplication.csproj
+++ b/SelfHosted/HostApplication/HostApplication.csproj
@@ -16,6 +16,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<StartupObject>Dvelop.Selfhosted.HostApplication.Program</StartupObject>
 		<RootNamespace>Dvelop.Selfhosted.HostApplication</RootNamespace>
+		<Nullable>disable</Nullable>
 	</PropertyGroup>
   
 

--- a/SelfHosted/HostApplication/Properties/launchSettings.json
+++ b/SelfHosted/HostApplication/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SYSTEMBASEURI": "http://localhost:5000",
-        "SIGNATURE_SECRET": "",
+        "SIGNATURE_SECRET": "VdJ2w+ZGq37NsIkKePptL7q+6JmhLf+jRMWvTcwwYRI=",
         "ASSET_BASE_PATH__": "https://s3-eu-central-1.amazonaws.com/assets.acme-apptemplatecs.hackathon.service.d-velop.cloud/d41d8cd98f00b204e9800998ecf8427e",
         "RELATIVE_ASSET_DIR": "$(SolutionDir)\\Remote\\wwwroot"
       }

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-focal
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal
 
 RUN wget https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
     dpkg -i packages-microsoft-prod.deb
@@ -12,54 +12,63 @@ RUN apt-get update && \
     apt-get install -y apt-transport-https
 
 RUN apt-get update && \
-    apt-get -y --fix-missing install dotnet-sdk-3.1 apt-utils sudo curl rsync unzip zip python3 python3-pip groff openssh-client git-core build-essential jq lsb-release software-properties-common
+	apt-get -y --fix-missing install ca-certificates apt-utils curl rsync unzip zip python3 python3-distutils python3-pip openssh-client git-core groff build-essential jq
+
 
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
-RUN apt-key fingerprint 0EBFCD88
-RUN add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable"
- 
-ENV TERRAFORM_MONGODBATLAS_PLUGIN_VERSION 1.0.1
-ENV TERRAFORM_AWS_PLUGIN_VERSION 3.54.0
+ENV TERRAFORM_VERSION 1.0.5
+ENV TERRAFORM_CHECKSUM 7ce24478859ab7ca0ba4d8c9c12bb345f52e8efdc42fa3ef9dd30033dbf4b561
+ENV TERRAFORM_AWS_PLUGIN_VERSION 3.75.1
+ENV TERRAFORM_AWS_PLUGIN_CHECKSUM ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8
+ENV TERRAFORM_TEMPLATE_PLUGIN_VERSION 2.2.0
+ENV TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM 8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae
+ENV TERRAFORM_TERRAFORM_PLUGIN_VERSION 2.2.0
+ENV TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65
 ENV TERRAFORM_ARCHIVE_PLUGIN_VERSION 2.2.0
+ENV TERRAFORM_ARCHIVE_PLUGIN_CHECKSUM e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65
+ENV PACKER_VERSION 1.2.5
+ENV PACKER_CHECKSUM bc58aa3f3db380b76776e35f69662b49f3cf15cf80420fc81a15ce971430824c
 
 #create terraforms default local provider structure
 RUN mkdir -p ~/.terraform.d ~/.terraform.d/plugins -p ~/.terraform.d/plugins/registry.terraform.io/ ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \
     mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws && \ 
+    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/template && \
     mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive && \
     cd ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \
     mkdir -p aws/${TERRAFORM_AWS_PLUGIN_VERSION} aws/${TERRAFORM_AWS_PLUGIN_VERSION}/linux_amd64 && \
     mkdir -p archive/${TERRAFORM_ARCHIVE_PLUGIN_VERSION} archive/${TERRAFORM_ARCHIVE_PLUGIN_VERSION}/linux_amd64 && \
-    cd ~/.terraform.d/plugins/registry.terraform.io/ && \
-    mkdir -p mongodb mongodb/mongodbatlas mongodb/mongodbatlas/${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION} mongodb/mongodbatlas/${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}/linux_amd64
+    mkdir -p template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION} template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/linux_amd64 && \
+    mkdir -p archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION} archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/linux_amd64
+    
+# packer
+
+RUN curl -fsSL https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -o packer.zip  && \
+    echo "${PACKER_CHECKSUM} packer.zip" | sha256sum -c - && \
+    unzip packer.zip -d /usr/local/bin && chmod +x /usr/local/bin/packer ; rm packer.zip
 
 # terraform
-ENV TERRAFORM_VERSION 1.0.5
-ENV TERRAFORM_CHECKSUM 7ce24478859ab7ca0ba4d8c9c12bb345f52e8efdc42fa3ef9dd30033dbf4b561
 RUN curl -fsSL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -o terraform.zip  && \
     echo "${TERRAFORM_CHECKSUM} terraform.zip" | sha256sum -c - && \
     unzip terraform.zip -d /usr/local/bin && chmod +x /usr/local/bin/terraform ; rm terraform.zip
 
-# terraform mongodbatlas provider plugin (for mongodbatlas)
-ENV TERRAFORM_MONGODBATLAS_PLUGIN_CHECKSUM 249959a4ce72f4ed94613e8baff00c4f571088511a7b908ab49ae42e5af5ead0
-RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-mongodbatlas/${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}/terraform-provider-mongodbatlas_${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}_linux_amd64.zip -o terraform_mongodbatlas_plugin.zip  && \
-    echo "${TERRAFORM_MONGODBATLAS_PLUGIN_CHECKSUM} terraform_mongodbatlas_plugin.zip" | sha256sum -c - && \
-    unzip terraform_mongodbatlas_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/mongodb/mongodbatlas/${TERRAFORM_MONGODBATLAS_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_mongodbatlas_plugin.zip
+# terraform template provider plugin
+RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/terraform-provider-template_${TERRAFORM_TEMPLATE_PLUGIN_VERSION}_linux_amd64.zip -o terraform_template_plugin.zip  && \
+    echo "${TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM} terraform_template_plugin.zip" | sha256sum -c - && \
+    unzip terraform_template_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/template/${TERRAFORM_TEMPLATE_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_template_plugin.zip
 
 # terraform aws provider plugin
-ENV TERRAFORM_AWS_PLUGIN_CHECKSUM f1f1a0bebd03e479b072dde9831f573070f6deada2972f5b966dd4858b99a8c2
 RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-aws/${TERRAFORM_AWS_PLUGIN_VERSION}/terraform-provider-aws_${TERRAFORM_AWS_PLUGIN_VERSION}_linux_amd64.zip -o terraform_aws_plugin.zip  && \
     echo "${TERRAFORM_AWS_PLUGIN_CHECKSUM} terraform_aws_plugin.zip" | sha256sum -c - && \
     unzip terraform_aws_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws/${TERRAFORM_AWS_PLUGIN_VERSION}/linux_amd64/  ; rm terraform_aws_plugin.zip
 
 # terraform terraform provider archive (for lambda)
-ENV TERRAFORM_ARCHIVE_PLUGIN_CHECKSUM e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65
+RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/terraform-provider-archive_${TERRAFORM_TERRAFORM_PLUGIN_VERSION}_linux_amd64.zip -o terraform_terraform_plugin.zip  && \
+    echo "${TERRAFORM_TERRAFORM_PLUGIN_CHECKSUM} terraform_terraform_plugin.zip" | sha256sum -c - && \
+    unzip terraform_terraform_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive/${TERRAFORM_TERRAFORM_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_terraform_plugin.zip
+
 RUN curl -fsSL https://releases.hashicorp.com/terraform-provider-archive/${TERRAFORM_ARCHIVE_PLUGIN_VERSION}/terraform-provider-archive_${TERRAFORM_ARCHIVE_PLUGIN_VERSION}_linux_amd64.zip -o terraform_terraform_plugin.zip  && \
     echo "${TERRAFORM_ARCHIVE_PLUGIN_CHECKSUM} terraform_terraform_plugin.zip" | sha256sum -c - && \
     unzip terraform_terraform_plugin.zip -d ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive/${TERRAFORM_ARCHIVE_PLUGIN_VERSION}/linux_amd64/ ; rm terraform_terraform_plugin.zip
@@ -70,9 +79,23 @@ RUN curl -sSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscli
     aws/install -i /usr/local/aws -b /usr/local/bin && \
     rm awscliv2.zip && rm -rf ./aws
 
+# node
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -; \
+	apt-get install -y nodejs
+RUN npm install -g markdown4documentation
+
+ENV VAULT_VERSION 1.8.2
+RUN curl -fsSL https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip -o vault_linux_amd64.zip  && \
+    unzip vault_linux_amd64.zip -d /usr/local/bin && chmod +x /usr/local/bin/vault ; rm vault_linux_amd64.zip
+
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
+RUN dotnet tool install -g trx2junit
+ENV PATH="${PATH}:~/.dotnet/tools"
 
 COPY umask.sh /
 RUN chmod +x /umask.sh
-
 
 ENTRYPOINT [ "/umask.sh" ]

--- a/buildcontainer/Dockerfile
+++ b/buildcontainer/Dockerfile
@@ -21,8 +21,8 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 ENV TERRAFORM_VERSION 1.0.5
 ENV TERRAFORM_CHECKSUM 7ce24478859ab7ca0ba4d8c9c12bb345f52e8efdc42fa3ef9dd30033dbf4b561
-ENV TERRAFORM_AWS_PLUGIN_VERSION 3.75.1
-ENV TERRAFORM_AWS_PLUGIN_CHECKSUM ecd664c0d664fcf2d8a89a01462cb00bcae37da200305aef2de1b8fe185c9cd8
+ENV TERRAFORM_AWS_PLUGIN_VERSION 4.8.0
+ENV TERRAFORM_AWS_PLUGIN_CHECKSUM 5758cbb813091db8573f27bba37c48f63ba95f2104f3bc49f13131e3c305b848
 ENV TERRAFORM_TEMPLATE_PLUGIN_VERSION 2.2.0
 ENV TERRAFORM_TEMPLATE_PLUGIN_CHECKSUM 8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae
 ENV TERRAFORM_TERRAFORM_PLUGIN_VERSION 2.2.0
@@ -34,7 +34,7 @@ ENV PACKER_CHECKSUM bc58aa3f3db380b76776e35f69662b49f3cf15cf80420fc81a15ce971430
 
 #create terraforms default local provider structure
 RUN mkdir -p ~/.terraform.d ~/.terraform.d/plugins -p ~/.terraform.d/plugins/registry.terraform.io/ ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \
-    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws && \ 
+    mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/aws && \
     mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/template && \
     mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/archive && \
     cd ~/.terraform.d/plugins/registry.terraform.io/hashicorp/ && \

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -10,9 +10,17 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.54.0"
-  constraints = "3.54.0"
+  version     = "3.75.1"
+  constraints = "3.75.1"
   hashes = [
-    "h1:iyxZssXd79FWHVGsMd1MuTO63LUum6JuVE0eJBWTYEs=",
+    "h1:++H0a4igODgreQL3SJuRz71JZkC69rl41R8xLYM894o=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
   ]
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -10,10 +10,10 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.75.1"
-  constraints = "3.75.1"
+  version     = "4.8.0"
+  constraints = "4.8.0"
   hashes = [
-    "h1:++H0a4igODgreQL3SJuRz71JZkC69rl41R8xLYM894o=",
+    "h1:T9Typ5V+dDwecG9USCLbW4oayxN3cxEGsG+OJzzjRgY=",
   ]
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 locals {
-  assets_bucket_name = "assets.${var.system_prefix}${var.appname}${var.domainsuffix}"
+  assets_bucket_name = "${var.system_prefix}${var.appname}-assets"
 
   lambda_file      = "../dist/lambda.zip"
   source_code_hash = filebase64sha256(local.lambda_file)
@@ -30,7 +30,7 @@ module "serverless_lambda_app" {
   # If you change your output file names or namespaces, you will have to edit the next line
   # <binary>::<name-space>.<class>::<function>
   lambda_handler     = "EntryPoint::Dvelop.Lambda.EntryPoint.LambdaEntryPoint::FunctionHandlerAsync"
-  lambda_runtime     = "dotnetcore3.1"
+  lambda_runtime     = "dotnet6"
   assets_bucket_name = local.assets_bucket_name
 
   # Which rights should the lambda function have.
@@ -45,7 +45,7 @@ module "serverless_lambda_app" {
     BUILD_VERSION    = local.build_version
     # change following entries if asset_cdn is enabled
     #ASSET_BASE_PATH  = "https://${module.asset_cdn.dns_name}/${var.asset_hash}"
-    ASSET_BASE_PATH = "https://s3-eu-central-1.amazonaws.com/${local.assets_bucket_name}/${var.asset_hash}"
+    ASSET_BASE_PATH = "https://${local.assets_bucket_name}.s3-eu-central-1.amazonaws.com/${var.asset_hash}"
   }
 
   aws_region = var.aws_region
@@ -55,7 +55,7 @@ module "serverless_lambda_app" {
 # If you use cloudfront (a CDN) to deliver your assets, you should remember to remove  's3-eu-central-1.amazonaws.com/' from this output. 
 # Otherwise the deployment will show a different configuration than used.
 output "asset_base_path" {
-  value = "https://s3-eu-central-1.amazonaws.com/${local.assets_bucket_name}/${var.asset_hash}"
+  value = "https://${local.assets_bucket_name}.amazonaws.com/${var.asset_hash}"
 }
 
 # Uncomment if you want to use cloudfront (a CDN) to deliver your assets OR custom domain names for your API endpoints.

--- a/terraform/modules/serverless_lambda_app/main.tf
+++ b/terraform/modules/serverless_lambda_app/main.tf
@@ -1,7 +1,14 @@
 #cf. https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
 resource "aws_s3_bucket" "assets" {
   bucket = var.assets_bucket_name
-  
+    
+  tags = {
+    Created_By = "Terraform - do not modify in AWS Management Console"
+  }
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = aws_s3_bucket.assets.id
   policy = <<POLICY
 {
   "Version":"2012-10-17",
@@ -15,11 +22,18 @@ resource "aws_s3_bucket" "assets" {
   ]
 }
 POLICY
-  
-  tags = {
-    Created_By = "Terraform - do not modify in AWS Management Console"
+}
+
+resource "aws_s3_bucket_cors_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  # required if webfonts are delivered cf. https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html and https://zinoui.com/blog/cross-domain-fonts
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
   }
 }
+
 
 # required if webfonts are delivered cf. https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html and https://zinoui.com/blog/cross-domain-fonts
 resource "aws_s3_bucket_public_access_block" "assets" {

--- a/terraform/modules/serverless_lambda_app/main.tf
+++ b/terraform/modules/serverless_lambda_app/main.tf
@@ -1,13 +1,7 @@
 #cf. https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
 resource "aws_s3_bucket" "assets" {
   bucket = var.assets_bucket_name
-
-  # required if webfonts are delivered cf. https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html and https://zinoui.com/blog/cross-domain-fonts
-  cors_rule {
-    allowed_methods = ["GET"]
-    allowed_origins = ["*"]
-  }
-
+  
   policy = <<POLICY
 {
   "Version":"2012-10-17",
@@ -21,10 +15,27 @@ resource "aws_s3_bucket" "assets" {
   ]
 }
 POLICY
-
-
+  
   tags = {
     Created_By = "Terraform - do not modify in AWS Management Console"
+  }
+}
+
+# required if webfonts are delivered cf. https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html and https://zinoui.com/blog/cross-domain-fonts
+resource "aws_s3_bucket_public_access_block" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  block_public_acls   = true
+  block_public_policy = false
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -5,3 +5,7 @@
 provider "archive" {
   # Configuration options
 }
+
+provider "template" {
+  # Configuration options
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,12 +1,16 @@
 terraform {
-  required_version = ">= 0.13.7"
+  required_version = ">= 1.0.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.54.0"
+      version = "3.75.1"
     }
     archive = {
       source  = "hashicorp/archive"
+      version = "2.2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
       version = "2.2.0"
     }
   }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.75.1"
+      version = "4.8.0"
     }
     archive = {
       source  = "hashicorp/archive"


### PR DESCRIPTION
Update the lambda configuration and lambda to run with dotnet 6.0
- Updates to dotnet 6.0
- Updates terraform to 1.0.5 (breaking changes, need manual update, first)